### PR TITLE
string-to-int is obsolete from Emacs 26 onward

### DIFF
--- a/tea-time.el
+++ b/tea-time.el
@@ -143,7 +143,7 @@ Cancel prevoius timer, started by this function"
   (interactive "sHow long (min)? ")
   (if (not (string-match "\\`\\([0-9]+\\)\\'" timeval))
       (tea-show-remaining-time)
-    (let* ((minutes (string-to-int (substring timeval (match-beginning 1)
+    (let* ((minutes (string-to-number (substring timeval (match-beginning 1)
 					      (match-end 1))))
 	   (seconds (* minutes 60)))
       (progn


### PR DESCRIPTION
Using the `string-to-number` function instead of `string-to-int`.